### PR TITLE
Cross-compatible check if FD is a TTY terminal

### DIFF
--- a/cmd/sshpiperd/internal/plugin/tty.go
+++ b/cmd/sshpiperd/internal/plugin/tty.go
@@ -1,24 +1,16 @@
 package plugin
 
 import (
+	"golang.org/x/term"
 	"io"
 	"os"
-
-	"golang.org/x/sys/unix"
 )
 
-const ioctlReadTermios = unix.TCGETS
-
-func isTerminal(fd int) bool {
-	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
-	return err == nil
-}
-
-// code from logrus
+// checkIfTerminal returns whether the given file descriptor is a terminal.
 func checkIfTerminal(w io.Writer) bool {
 	switch v := w.(type) {
 	case *os.File:
-		return isTerminal(int(v.Fd()))
+		return term.IsTerminal(int(v.Fd()))
 	default:
 		return false
 	}


### PR DESCRIPTION
 Package `term` provides support functions for dealing with terminals, cross-compatible with Unix,darwin and windows.

 The low leve const `unix.TCGETS` is not defined in Darwin arch, ad prevent shspiper to buil and run on osx